### PR TITLE
Cambio de Discretas 1 y Discretas 2

### DIFF
--- a/Curricula.in/lang/Espanol/CS.sty/bok-macros.sty
+++ b/Curricula.in/lang/Espanol/CS.sty/bok-macros.sty
@@ -1206,7 +1206,9 @@ Dado que las estructuras discretas sirve como base para muchas otras áreas de l
 \newcommand{\DSSetsRelationsandFunctionsTopicRelations}{Relaciones:
 \begin{subtopics}
 \item Reflexividad, simetria, transitividad
-\item Relaciones equivalentes, ordenes parciales
+\item Relaciones de equivalencia
+\item Relación de orden parcial y conjuntos parcialmente ordenados
+\item Elementos extremos de un conjunto parcialmente ordenado
 \end{subtopics}\xspace}
 \newcommand{\DSSetsRelationsandFunctionsTopicFunctions}{Funciones:
 \begin{subtopics}

--- a/Curricula.in/lang/Espanol/cycle/2018-II/Syllabi/Computing/CS/CS1D1.tex
+++ b/Curricula.in/lang/Espanol/cycle/2018-II/Syllabi/Computing/CS/CS1D1.tex
@@ -51,7 +51,7 @@ Criptografía, métodos formales, etc.
     \item \ShowCompetence{C20}{6}
 \end{competences}
 
-\begin{unit}{\DSSetsRelationsandFunctions}{}{Grimaldi03,Rosen2007}{13}{C1,C20}
+\begin{unit}{\DSSetsRelationsandFunctions}{}{Grimaldi03,Rosen2007}{22}{C1,C20}
    \begin{topics}
         \item \DSSetsRelationsandFunctionsTopicSets
         \item \DSSetsRelationsandFunctionsTopicRelations
@@ -111,29 +111,19 @@ Criptografía, métodos formales, etc.
 \end{learningoutcomes}
 \end{unit}
 
-\begin{unit}{Lógica Digital y Representación de Datos}{}{Rosen2007,Grimaldi03}{19}{C1,C20}
+\begin{unit}{Representación de Datos}{}{Rosen2007}{10}{C1,C20}
    \begin{topics}
-	\item Órdenes parciales y Conjuntos parcialmente ordenados.   
- 	\item Elementos extremos de un conjunto parcialmente ordenado.
-	\item Reticulo: Tipos y propiedades.
-	\item Álgebras booleanas.
-	\item Funciones y expresiones booleanas.
-	\item Representación de las funciones booleanas: Disjuntiva normal y forma conjunta.
-	\item Puertas Lógicas.
-	\item Minimización del Circuito.
+	\item Representaciones numéricas: signo magnitud, punto flotante.
+        \item Representaciones de otros objetos: conjuntos, relaciones, funciones
    \end{topics}
 
    \begin{learningoutcomes}
-	\item Explicar la importancia del álgebra booleana como una unificación de la teoría de conjuntos y la lógica proposicional [\Assessment].
-	\item Conocer las estructuras algebraicas del retículo y sus tipos [\Assessment].
-	\item Explicar la relación entre el retículo y el conjunto de ordenadas y el uso prudente para demostrar que un conjunto es un retículo [\Assessment].
-	\item Conocer las propiedades que satisfacen un álgebra booleana [\Assessment].
-	\item Demostrar si una terna formada por un conjunto y dos operaciones internas es o no Álgebra booleana [\Assessment].
-	\item Encuentra las formas canónicas de una función booleana  [\Assessment].
-	\item Representar una función booleana como un circuito booleano usando puertas lógica[\Assessment].
-	\item Minimizar una función booleana [\Assessment].
-    \end{learningoutcomes}
+        \item Conocer las formas de representación numérica como signo magnitud y punto flotante. [\Assessment].
+        \item Llevar a cabo operaciones aritméticas utilizando las distintas formas de representación. [\Assessment].
+        \item Conocer el estándar de punto flotante IEEE-754 [\Familiarity].    
+  \end{learningoutcomes}
 \end{unit}
+
 
 \begin{coursebibliography}
 \bibfile{Computing/CS/CS1D1}

--- a/Curricula.in/lang/Espanol/cycle/2018-II/Syllabi/Computing/CS/CS1D2.tex
+++ b/Curricula.in/lang/Espanol/cycle/2018-II/Syllabi/Computing/CS/CS1D2.tex
@@ -36,6 +36,28 @@ diversas estructuras discretas, estructuras que serán implementadas y usadas en
     \item \ShowCompetence{CS2}{6}
 \end{competences}
 
+\begin{unit}{Lógica Digital y Representación de Datos}{}{Rosen2007,Grimaldi03}{10}{C1,C20}
+   \begin{topics}
+        \item Retículo: Tipos y propiedades.
+        \item Álgebras booleanas.
+        \item Funciones y expresiones booleanas.
+        \item Representación de las funciones booleanas: Disjuntiva normal y forma conjunta.
+        \item Puertas Lógicas.
+        \item Minimización del Circuito.
+   \end{topics}
+
+   \begin{learningoutcomes}
+        \item Explicar la importancia del álgebra booleana como una unificación de la teoría de conjuntos y la lógica proposicional [\Assessment].
+        \item Conocer las estructuras algebraicas del retículo y sus tipos [\Assessment].
+        \item Explicar la relación entre el retículo y el conjunto de ordenadas y el uso prudente para demostrar que un conjunto es un retículo [\Assessment].
+        \item Conocer las propiedades que satisfacen un álgebra booleana [\Assessment].
+        \item Demostrar si una terna formada por un conjunto y dos operaciones internas es o no Álgebra booleana [\Assessment].
+        \item Encuentra las formas canónicas de una función booleana  [\Assessment].
+        \item Representar una función booleana como un circuito booleano usando puertas lógica[\Assessment].
+        \item Minimizar una función booleana [\Assessment].
+    \end{learningoutcomes}
+\end{unit}
+
 \begin{unit}{\DSBasicsofCounting}{}{Grimaldi97}{45}{C1} 
     \begin{topics}
         \item \DSBasicsofCountingTopicCounting


### PR DESCRIPTION
Se hace este cambio para que los tópicos estén más cerca del curso de Arquitectura de Computadores.  Los tópicos son Álgebra boolena, compuertas logicos y minimización de circuíto.  Se agrega representacion de punto flotante para contribuir con arquitectura de computares.